### PR TITLE
Update to skrooge 2.20.0 to fix build problem and runtime failure

### DIFF
--- a/org.kde.skrooge.yml
+++ b/org.kde.skrooge.yml
@@ -121,5 +121,5 @@ modules:
       - -DQt5WebKitWidgets_DIR=/app/lib/cmake/Qt5WebKitWidgets
     sources:
       - type: archive
-        url: https://download.kde.org/stable/skrooge/skrooge-2.18.0.tar.xz
-        sha256: 4671dfe736d92c2de51a872b49bfbdc251e7e869b5672b6546b85aca4409f303
+        url: https://download.kde.org/stable/skrooge/skrooge-2.20.0.tar.xz
+        sha256: 3c58c54ad048b03608fde0b794de0cd3a83d0b5bd43c1d033c5dc8739f755365


### PR DESCRIPTION
The fix to org.kde.skrooge.appdata.xml for the build #4777 failure ([KDE bug 409026](https://bugs.kde.org/show_bug.cgi?id=409026)) is in skrooge version 2.20. A rebuild should also address issue #7 .