### PR TITLE
Add sound permission

### DIFF
--- a/org.kde.skrooge.json
+++ b/org.kde.skrooge.json
@@ -24,6 +24,7 @@
       "--share=ipc",
       "--socket=x11",
       "--socket=wayland",
+      "--socket=pulseaudio",
       "--device=dri",
       "--filesystem=host"
    ],


### PR DESCRIPTION
A user reported "the Skrooge KDE package usually plays happy noises (ka-ching!?), but the Skrooge flatpak app doesn't" because it doesn't have access to sound. Now it does.