### PR TITLE
Update flatpak's runtime to 5.15-22, other tweaks

### DIFF
--- a/org.kde.skrooge.json
+++ b/org.kde.skrooge.json
@@ -2,10 +2,10 @@
     "id": "org.kde.skrooge",
     "default-branch": "stable",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.15-21.08",
+    "runtime-version": "5.15-22.08",
     "sdk": "org.kde.Sdk",
     "base": "io.qt.qtwebkit.BaseApp",
-    "base-version": "5.15-21.08",
+    "base-version": "5.15-22.08",
     "command": "skrooge",
     "rename-icon": "skrooge",
     "copy-icon": true,
@@ -30,13 +30,13 @@
     "modules": [
         {
             "name": "tcl",
+            "//": "sqlcipher requires tclsh during build",
             "subdir": "unix",
             "build-options": {
                 "no-debuginfo": true
             },
             "cleanup": [
-                "/bin",
-                "/man"
+                "/*"
             ],
             "sources": [
                 {
@@ -161,7 +161,11 @@
         },
         {
             "name": "gengetopt",
+            "//": "libofx requires gengetopt during build",
             "rm-configure": true,
+            "cleanup": [
+                "/*"
+            ],
             "sources": [
                 {
                     "type": "archive",


### PR DESCRIPTION
Update org.kde.Platform and io.qt.qtwebkit.BaseApp to 5.15-22. Also more aggressive cleanup of some build-only dependencies and comment why they're there. These changes minimize the differences between flathub's recipe for the stable build and the project's recipe for the master build on kdeapps.

TESTING: I made the same changes to https://invent.kde.org/office/skrooge/-/blob/master/org.kde.skrooge.json, and following https://docs.flatpak.org/en/latest/first-build.html it built and ran OK.